### PR TITLE
Bump template-haskell for 7.10.1

### DIFF
--- a/snap-loader-static.cabal
+++ b/snap-loader-static.cabal
@@ -25,7 +25,7 @@ Library
 
   build-depends:
     base              >= 4       && < 5,
-    template-haskell  >= 2.2     && < 2.10
+    template-haskell  >= 2.2     && < 2.11
 
   if impl(ghc >= 6.12.0)
     ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2


### PR DESCRIPTION
For #4 

Tested with `snap init default` and `7.10.1`