### PR TITLE
Bumped snap-loader-static to support template-haskell-2.10 as per #6

### DIFF
--- a/snap-loader-static.cabal
+++ b/snap-loader-static.cabal
@@ -25,7 +25,7 @@ Library
 
   build-depends:
     base              >= 4       && < 5,
-    template-haskell  >= 2.2     && < 2.10
+    template-haskell  >= 2.2     && < 2.11
 
   if impl(ghc >= 6.12.0)
     ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2


### PR DESCRIPTION
This makes it actually compile with base-4.8. I have tested this on my machine with before and after installs.