### PR TITLE
Update snap-loader-static.cabal

### DIFF
--- a/snap-loader-static.cabal
+++ b/snap-loader-static.cabal
@@ -27,7 +27,7 @@ Library
 
   build-depends:
     base              >= 4       && < 5,
-    template-haskell  >= 2.2     && < 2.14
+    template-haskell  >= 2.2     && < 2.15
 
   if impl(ghc >= 6.12.0)
     ghc-options: -Wall -fwarn-tabs -funbox-strict-fields


### PR DESCRIPTION
Bump template-haskell upper bound so I can compile with ghc-8.6.2