### PR TITLE
Extend support to more recent GHC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,15 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.3"
+    - compiler: "ghc-8.10.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.10.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.8.4"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.8.4], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.6.5], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}

--- a/snap-loader-static.cabal
+++ b/snap-loader-static.cabal
@@ -11,7 +11,7 @@ cabal-version:  >= 1.8
 homepage:       http://snapframework.com/
 category:       Web, Snap
 Tested-With:    GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3,
-                GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.3
+                GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2
 
 extra-source-files:
   CONTRIBUTORS,
@@ -27,7 +27,7 @@ Library
 
   build-depends:
     base              >= 4       && < 5,
-    template-haskell  >= 2.2     && < 2.15
+    template-haskell  >= 2.2     && < 3
 
   if impl(ghc >= 6.12.0)
     ghc-options: -Wall -fwarn-tabs -funbox-strict-fields


### PR DESCRIPTION
Resolve #11.

I could not use this package with GHC 8.8 and later, so I bumped some version bounds and adjusted Travis configuration as appropriate. Would be great if you folks can merge and make a Hackage release.